### PR TITLE
fix: Improve button functionality in cart quantity control below items

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -26,11 +26,16 @@ function updateButtonText(itemName) {
     button.innerHTML = `
         <div class="quantity">
             <span class="minus" onclick="decreaseQuantity('${itemName}')">-</span>
-            ${cart[itemName].quantity}
+            <span class='itemQty'>${cart[itemName].quantity}</span>
             <span class="plus" onclick="increaseQuantity('${itemName}')">+</span>
         </div>
         `;
+    button.onclick = null;
   } else {
+    const itemDiv = button.closest('div.item');
+    const priceP = itemDiv.querySelector('p.price');
+    const itemPrice = parseFloat(priceP.textContent.replace('$', ''));
+    button.onclick = () => addToCart(itemName, itemPrice);
     button.innerHTML = `
             <img class="cartimage" src="assets/images/add-to-cart.png" alt="Add to Cart Icon">
             Add to Cart

--- a/assets/style.css
+++ b/assets/style.css
@@ -23,6 +23,7 @@ body {
   padding: 20px;
   margin: 20px;
 }
+
 /* Product section */
 .menu {
   display: flex;
@@ -59,6 +60,7 @@ body {
   margin: 10px 0;
   font-weight: bold;
 }
+
 .addtocart {
   display: inline-flex;
   align-items: center;
@@ -74,10 +76,12 @@ body {
   cursor: pointer;
   transition: all 0.3s ease;
 }
+
 .addtocart img {
   width: 20px;
   height: 20px;
 }
+
 .addtocart:hover,
 .addtocart:focus {
   background-color: #e4634a;
@@ -89,6 +93,7 @@ body {
   font-family: Cambria, Cochin, Georgia, Times, "Times New Roman", serif;
   width: 80%;
 }
+
 .cart-content {
   background-color: #f9f9f9;
   border: 1px solid #ccc;
@@ -123,7 +128,9 @@ body {
 }
 
 .quantity {
-  padding: 0px 18px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .total {
@@ -163,6 +170,7 @@ body {
 .modal-content p {
   margin: 10px 0;
 }
+
 .close-button {
   float: right;
   font-size: 20px;
@@ -170,7 +178,10 @@ body {
 }
 
 .quantity .minus,
-.quantity .plus {
+.quantity .plus,
+.quantity .itemQty {
+  padding-left: 13px;
+  padding-right: 13px;
   cursor: pointer;
-  width: 20px;
+  display: inline-block;
 }


### PR DESCRIPTION
Good day,

I visited the hosted version of this site and discovered a bit of a bug.
When the minus and plus buttons are shown below the items, clicking anywhere else on the button except exactly on the minus sign led to an increment in quantity. This PR:
- Fixes the functionality of the button to ensure there is no incrementing when a user clicks around the minus.
- Adds a bit of padding to both the minus and plus buttons to make them a bit more forgiving for user input.

I added a demo video of the before and after if my explanation is unclear. You can access the videos by clicking [here](https://drive.google.com/drive/folders/1O8mwLEkAAyx2OvRA1Hyz3oynwdHF8GSB?usp=sharing).

Thank you.

P.S: This project popped up on my feed because of my boss @samuelogboye 🌚😂